### PR TITLE
Disable data-upload-max-num-fields

### DIFF
--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -48,6 +48,8 @@ ROOT_URLCONF = "project.urls"
 # https://docs.djangoproject.com/en/4.2/ref/settings/#wsgi-application
 WSGI_APPLICATION = "project.wsgi.application"
 
+# https://docs.djangoproject.com/en/5.1/ref/settings/#data-upload-max-number-fields
+DATA_UPLOAD_MAX_NUMBER_FIELDS=None
 
 ################################################################################
 #                Internationalization and localization                         #

--- a/src/project/settings.py
+++ b/src/project/settings.py
@@ -49,7 +49,7 @@ ROOT_URLCONF = "project.urls"
 WSGI_APPLICATION = "project.wsgi.application"
 
 # https://docs.djangoproject.com/en/5.1/ref/settings/#data-upload-max-number-fields
-DATA_UPLOAD_MAX_NUMBER_FIELDS=None
+DATA_UPLOAD_MAX_NUMBER_FIELDS = None
 
 ################################################################################
 #                Internationalization and localization                         #


### PR DESCRIPTION
In the method admin view, trying to assign a new indicator to the method and moving it from one column to another, when saving the method the following error appeared.

<img width="1677" height="474" alt="Screenshot from 2026-01-14 14-41-54" src="https://github.com/user-attachments/assets/6bb3188b-ff81-4b02-8cb3-41b5894be7de" />

Fixed according to django docs https://docs.djangoproject.com/en/5.1/ref/settings/#data-upload-max-number-fields