### PR TITLE
Remove unused code

### DIFF
--- a/src/apps/settings/admin.py
+++ b/src/apps/settings/admin.py
@@ -1,7 +1,4 @@
 from django.contrib import admin
-from django.urls import reverse
-from django.utils.html import escapejs, format_html
-from django.utils.translation import gettext as _
 from modeltranslation.admin import TabbedTranslationAdmin
 
 from project.admin import ModelAdmin, gov_admin_site
@@ -37,74 +34,18 @@ class NetworkAdmin(ModelAdmin):
     search_fields = ["name"]
     list_display = ("name", "parent_network")
     filter_horizontal = ("organizations", "methods", "campaigns")
-    fieldsets = (
-        (
-            "",
-            {
-                "fields": (
-                    "name",
-                    "parent_network",
-                    "organizations",
-                    "campaigns",
-                    "methods",
-                )
-            },
-        ),
-    )
     autocomplete_fields = ["parent_network"]
 
-    common_fieldsets = (
-        (
-            _("Actions"),
-            {"fields": ("actions_field",)},
-        ),
-        (
-            _("Log"),
-            {
-                "fields": (
-                    "created_by",
-                    "created_at",
-                    "updated_at",
-                )
-            },
-        ),
-    )
-
-    readonly_fields = ("actions_field",)
-
     def get_fieldsets(self, request, obj=None):
-        return super().get_fieldsets(request, obj) + self.common_fieldsets
-
-    @admin.display(description=_("Actions"))
-    def actions_field(self, obj):
-        if not obj or not self.request.user.groups.filter(name="Network Admins"):
-            return "-"
-        confirmed_verification_msg = _(
-            "Are you sure you want to send an email to the user to notify they "
-            "have been added as network admin?"
-        )
-        confirmed_verification_url = reverse(
-            "settings:admin_assigned",
-            args=[obj.id],
-        )
-        confirmed_verification_text = _(
-            "Send email to the user to notify they have been added as network admin"
-        )
-        buttons = [
-            self._get_url_with_alert_msg(
-                confirmed_verification_msg,
-                confirmed_verification_url,
-                confirmed_verification_text,
-            )
-        ]
-        return format_html("<br><br>".join(buttons))
-
-    def _get_url_with_alert_msg(self, alert_msg, url, text):
-        return format_html(
-            f'<a class="bg-primary-600 block border border-transparent font-medium px-3'
-            ' py-2 rounded-md text-white" style="width: 50%; text-align: center;"'
-            f"href=\"javascript:if(confirm('{escapejs(alert_msg)}')) "
-            f"window.location.href = '{url}'\">{text}</a>"
+        return self.build_fieldsets(
+            main_fields=[
+                "name",
+                "parent_network",
+                "organizations",
+                "campaigns",
+                "methods",
+            ],
+            translatable_fields=None,
         )
 
 

--- a/src/apps/settings/urls.py
+++ b/src/apps/settings/urls.py
@@ -7,13 +7,11 @@ from apps.settings.views import (
     GoodPracticesView,
     ResourcesView,
     WhatIsSocialBalanceView,
-    admin_assigned_view,
 )
 
 app_name = "settings"
 urlpatterns = [
     # Settings
-    path(_("admin-assigned/<id>"), admin_assigned_view, name="admin_assigned"),
     path(
         _("what-is-social-balance"),
         WhatIsSocialBalanceView.as_view(),

--- a/src/apps/settings/views.py
+++ b/src/apps/settings/views.py
@@ -1,27 +1,6 @@
-from django.contrib import messages
-from django.http import HttpResponseRedirect
-from django.urls import reverse_lazy
-from django.utils.translation import gettext_lazy as _
 from django.views.generic import TemplateView
 
 from apps.methods.models import Campaign, Survey
-from apps.settings.models import Network
-from apps.users.services import send_network_assigned_mail
-
-
-def admin_assigned_view(request, id):
-    network = Network.objects.get(pk=id)
-    send_network_assigned_mail(network)
-    messages.success(
-        request,
-        _(
-            "An email has been sent to the user to inform that he is now "
-            " administrator of the network."
-        ),
-    )
-    return HttpResponseRedirect(
-        reverse_lazy("admin:settings_network_change", args=(network.id,))
-    )
 
 
 class WhatIsSocialBalanceView(TemplateView):

--- a/src/apps/users/services.py
+++ b/src/apps/users/services.py
@@ -98,27 +98,3 @@ def send_rejected_mail(user_instance):
         template="rejected_registration_request",
         context=context,
     )
-
-
-def send_network_assigned_mail(network_instance):
-    context = {
-        "project_name": Setting.get("PROJECT_NAME"),
-        "user_name": network_instance.network_admin.name,
-        "date": str(
-            formats.date_format(
-                timezone.now().date(),
-                format="SHORT_DATE_FORMAT",
-                use_l10n=True,
-            )
-        ),
-        "time": str(formats.time_format(timezone.localtime(timezone.now()).time())),
-        "network_name": network_instance.name,
-    }
-
-    send(
-        recipients=[
-            network_instance.network_admin.email,
-        ],
-        template="network_assigned",
-        context=context,
-    )

--- a/src/project/management/commands/load_email_templates.py
+++ b/src/project/management/commands/load_email_templates.py
@@ -58,17 +58,6 @@ class Command(BaseCommand):
                 },
             ),
             dict(
-                id="network_assigned",
-                translated_templates={
-                    "en": {
-                        "subject": "Network assigned on {{project_name}}",
-                        "body": open(
-                            "./templates/emails/en/network_assigned.html"
-                        ).read(),
-                    },
-                },
-            ),
-            dict(
                 id="welcome",
                 translated_templates={
                     "en": {


### PR DESCRIPTION
After the removal of the network_admin of the Network model, the code removed here was unused, as it served for sending an email to the new assigned person