### PR TITLE
Automatically add network on organization creation

### DIFF
--- a/src/apps/organizations/forms.py
+++ b/src/apps/organizations/forms.py
@@ -206,6 +206,25 @@ class OrganizationSignUpForm(forms.ModelForm):
                 if network not in organization.networks.all():
                     organization.networks.add(network)
 
+        full_address = ", ".join(
+            filter(
+                None,
+                [
+                    self.cleaned_data["address"],
+                    str(self.cleaned_data["city"]),
+                    str(self.cleaned_data["region1"]),
+                    str(self.cleaned_data["zip_code"]),
+                ],
+            )
+        )
+
+        coords = get_coordinates_from_address(full_address)
+
+        if coords:
+            lat, lng = coords
+            organization.latitude = lat
+            organization.longitude = lng
+
         if commit:
             organization.save()
             # save(commit=False) used before does not save the many to

--- a/src/apps/organizations/forms.py
+++ b/src/apps/organizations/forms.py
@@ -14,6 +14,7 @@ from apps.settings.models import LegalStructure
 from apps.users.models import User, UserProfile
 from apps.users.services import send_registration_mail
 
+from .helpers import get_coordinates_from_address
 from .models import Organization, Project
 
 
@@ -198,6 +199,13 @@ class OrganizationSignUpForm(forms.ModelForm):
                 "organization": organization,
             },
         )
+
+        # Automatically add the organization to the method's networks
+        for method in self.cleaned_data["methods"]:
+            for network in method.networks.all():
+                if network not in organization.networks.all():
+                    organization.networks.add(network)
+
         if commit:
             organization.save()
             # save(commit=False) used before does not save the many to

--- a/src/apps/organizations/models.py
+++ b/src/apps/organizations/models.py
@@ -85,6 +85,12 @@ class Organization(BaseModel):
             if profile and not profile.user.email_verified and sender_user:
                 send_welcome_mail(profile.user, sender_user=sender_user)
 
+        # Automatically add the organization to the method's networks
+        for method in self.methods.all():
+            for network in method.networks.all():
+                if network not in self.networks.all():
+                    self.networks.add(network)
+
         full_address = ", ".join(
             filter(
                 None,


### PR DESCRIPTION
Closes #492 

The coordinates only were saved on organization update from the admin. Now they are also saved on organization creation 